### PR TITLE
chore(BUX-223): adjust endpoints to new bux-server router

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -78,8 +78,6 @@ describe('SPVWalletClient routing', () => {
     ${'GetUtxo'}                                               | ${'get'}    | ${'utxo?tx_id=&output_index=0'}  | ${() => spvWalletClient.GetUtxo("", 0)}
     ${'GetUtxos'}                                              | ${'post'}   | ${'utxo/search'}                 | ${() => spvWalletClient.GetUtxos({}, {}, {})}
     ${'GetUtxosCount'}                                         | ${'post'}   | ${'utxo/count'}                  | ${() => spvWalletClient.GetUtxosCount({}, {})}
-    ${'NewPaymail'}                                            | ${'post'}   | ${'paymail'}                     | ${() => spvWalletClient.NewPaymail("", "")}
-    ${'DeletePaymail'}                                         | ${'delete'} | ${'paymail'}                     | ${() => spvWalletClient.DeletePaymail("")}
     `("$spvWalletMethod", async ({ path, httpMethod, act }) => {
 
     // given
@@ -109,7 +107,7 @@ describe('SPVWalletClient admin routing', () => {
 
   it.each`
     spvWalletMethod                      | httpMethod  | path                            | act
-    ${'RegisterXpub'}                    | ${'post'}   | ${'xpub'}                       | ${() => adminSPVWalletClient.RegisterXpub('', {})}
+    ${'AdminNewXpub'}                    | ${'post'}   | ${'admin/xpub'}                 | ${() => adminSPVWalletClient.AdminNewXpub('', {})}
     ${'AdminGetStatus'}                  | ${'get'}    | ${'admin/status'}               | ${() => adminSPVWalletClient.AdminGetStatus()}
     ${'AdminGetStats'}                   | ${'get'}    | ${'admin/stats'}                | ${() => adminSPVWalletClient.AdminGetStats()}
     ${'AdminGetAccessKeys'}              | ${'post'}   | ${'admin/access-keys/search'}   | ${() => adminSPVWalletClient.AdminGetAccessKeys({}, {}, {})}

--- a/src/index.ts
+++ b/src/index.ts
@@ -293,7 +293,7 @@ class SpvWalletClient implements TransportService {
   /**
    * Admin only: Delete a paymail
    *
-   * @param address string Paymail address (ie. example@bux.org)
+   * @param address string Paymail address (ie. example@spv-wallet.org)
    * @return void
    */
   async AdminDeletePaymail(address: string): Promise<void> {
@@ -370,7 +370,7 @@ class SpvWalletClient implements TransportService {
   }
 
   /**
-   * Admin only: Register a new xPub into the Bux server
+   * Admin only: Register a new xPub into the SPV Wallet
    *
    * @param {string} rawXPub    XPub string
    * @param {Metadata} metadata Key value object to use to add to the xpub

--- a/src/index.ts
+++ b/src/index.ts
@@ -293,11 +293,11 @@ class SpvWalletClient implements TransportService {
   /**
    * Admin only: Delete a paymail
    *
-   * @param address string Paymail address (i.e. alias@example.com)
-   * @return {PaymailAddress}
+   * @param address string Paymail address (ie. example@bux.org)
+   * @return void
    */
-  async AdminDeletePaymail(address: string): Promise<PaymailAddress> {
-    return await this.client.httpTransport.AdminDeletePaymail(address);
+  async AdminDeletePaymail(address: string) {
+    this.client.httpTransport.AdminDeletePaymail(address);
   }
 
   /**
@@ -367,6 +367,17 @@ class SpvWalletClient implements TransportService {
    */
   async AdminGetXPubsCount(conditions: Conditions, metadata: Metadata): Promise<number> {
     return await this.client.httpTransport.AdminGetXPubsCount(conditions, metadata);
+  }
+
+  /**
+   * Admin only: Register a new xPub into the Bux server
+   *
+   * @param {string} rawXPub    XPub string
+   * @param {Metadata} metadata Key value object to use to add to the xpub
+   * @return {XPub}             The newly registered xpub
+   */
+  async AdminNewXpub(rawXPub: string, metadata: Metadata): Promise<XPub> {
+    return await this.client.httpTransport.AdminNewXpub(rawXPub, metadata);
   }
 
   /**
@@ -561,34 +572,6 @@ class SpvWalletClient implements TransportService {
    */
   async UpdateDestinationMetadataByAddress(address: string, metadata: Metadata): Promise<Destination> {
     return await this.client.httpTransport.UpdateDestinationMetadataByAddress(address, metadata);
-  }
-
-  /**
-   * Register a new paymail
-   * @param {string} key - The rawXPubKey
-   * @param {string} address - The full paymail address
-   * @param {string} [publicName] - The public name (optional)
-   * @param {string} [avatar] - The avatar (optional)
-   * @param {Metadata} [metadata] - The metadata to record on the destination (optional)
-   * @returns {void}
-   */
-  async NewPaymail(
-    key: string,
-    address: string,
-    publicName?: string,
-    avatar?: string,
-    metadata?: Metadata
-  ): Promise<void> {
-    return this.client.httpTransport.NewPaymail(key, address, publicName, avatar, metadata);
-  }
-
-  /**
-   * Delete paymail
-   * @param {string} address - The full paymail address
-   * @returns {void}
-   */
-  async DeletePaymail(address: string): Promise<void> {
-    return this.client.httpTransport.DeletePaymail(address);
   }
 
   /**
@@ -794,18 +777,6 @@ class SpvWalletClient implements TransportService {
   async UpdateTransactionMetadata(txID: string, metadata: Metadata): Promise<Transaction> {
     return await this.client.httpTransport.UpdateTransactionMetadata(txID, metadata);
   }
-
-  /**
-   * Admin only: Register a new xPub into the SPV Wallet server
-   *
-   * @param {string} rawXPub    XPub string
-   * @param {Metadata} metadata Key value object to use to add to the xpub
-   * @return {XPub}             The newly registered xpub
-   */
-  async RegisterXpub(rawXPub: string, metadata: Metadata): Promise<XPub> {
-    return await this.client.httpTransport.RegisterXpub(rawXPub, metadata);
-  }
-
 }
 
 const generateKeys = function(): KeyWithMnemonic {

--- a/src/index.ts
+++ b/src/index.ts
@@ -268,6 +268,7 @@ class SpvWalletClient implements TransportService {
 
   /**
    * Admin only: Get a count of all paymails in the system, filtered by conditions, metadata and queryParams
+   * To get a count of not-deleted paymails, use the condition: { deleted_at: null }
    *
    * @param {Conditions} conditions   Key value object to use to filter the documents
    * @param {Metadata} metadata       Key value object to use to filter the documents by the metadata
@@ -297,7 +298,7 @@ class SpvWalletClient implements TransportService {
    * @return void
    */
   async AdminDeletePaymail(address: string): Promise<void> {
-    return await this.client.httpTransport.AdminDeletePaymail(address);
+    await this.client.httpTransport.AdminDeletePaymail(address);
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -296,8 +296,8 @@ class SpvWalletClient implements TransportService {
    * @param address string Paymail address (ie. example@bux.org)
    * @return void
    */
-  async AdminDeletePaymail(address: string) {
-    this.client.httpTransport.AdminDeletePaymail(address);
+  async AdminDeletePaymail(address: string): Promise<void> {
+    return await this.client.httpTransport.AdminDeletePaymail(address);
   }
 
   /**

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -575,7 +575,7 @@ export interface TransportService {
   AdminGetPaymails(conditions: Conditions, metadata: Metadata, queryParams: QueryParams): Promise<PaymailAddresses>
   AdminGetPaymailsCount(conditions: Conditions, metadata: Metadata): Promise<number>
   AdminCreatePaymail(xPubID: string, address: string, public_name: string, avatar: string): Promise<PaymailAddress>
-  AdminDeletePaymail(address: string): void
+  AdminDeletePaymail(address: string): Promise<void>
   AdminGetTransactions(conditions: Conditions, metadata: Metadata, queryParams: QueryParams): Promise<Transactions>
   AdminGetTransactionsCount(conditions: Conditions, metadata: Metadata): Promise<number>
   AdminGetUtxos(conditions: Conditions, metadata: Metadata, queryParams: QueryParams): Promise<Utxos>

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -563,7 +563,6 @@ export interface TransportService {
   IsDebug(): boolean;
   SetSignRequest(debug: boolean): void;
   IsSignRequest(): boolean;
-  RegisterXpub(rawXPub: string, metadata: Metadata): Promise<XPub>;
   AdminGetStatus(): Promise<boolean>
   AdminGetStats(): Promise<AdminStats>
   AdminGetAccessKeys(conditions: Conditions, metadata: Metadata, queryParams: QueryParams): Promise<AccessKeys>
@@ -576,13 +575,14 @@ export interface TransportService {
   AdminGetPaymails(conditions: Conditions, metadata: Metadata, queryParams: QueryParams): Promise<PaymailAddresses>
   AdminGetPaymailsCount(conditions: Conditions, metadata: Metadata): Promise<number>
   AdminCreatePaymail(xPubID: string, address: string, public_name: string, avatar: string): Promise<PaymailAddress>
-  AdminDeletePaymail(address: string): Promise<PaymailAddress>
+  AdminDeletePaymail(address: string): void
   AdminGetTransactions(conditions: Conditions, metadata: Metadata, queryParams: QueryParams): Promise<Transactions>
   AdminGetTransactionsCount(conditions: Conditions, metadata: Metadata): Promise<number>
   AdminGetUtxos(conditions: Conditions, metadata: Metadata, queryParams: QueryParams): Promise<Utxos>
   AdminGetUtxosCount(conditions: Conditions, metadata: Metadata): Promise<number>
   AdminGetXPubs(conditions: Conditions, metadata: Metadata, queryParams: QueryParams): Promise<XPubs>;
-  AdminGetXPubsCount(conditions: Conditions, metadata: Metadata): Promise<number>;
+  AdminGetXPubsCount(conditions: Conditions, metadata: Metadata): Promise<number>
+  AdminNewXpub(rawXPub: string, metadata: Metadata): Promise<XPub>;
   AdminRecordTransaction(hex: string): Promise<Transaction>;
   GetXPub(): Promise<XPub>;
   UpdateXPubMetadata(metadata: Metadata): Promise<XPub>;
@@ -600,8 +600,6 @@ export interface TransportService {
   UpdateDestinationMetadataByID(id: string, metadata: Metadata): Promise<Destination>;
   UpdateDestinationMetadataByAddress(address: string, metadata: Metadata): Promise<Destination>;
   UpdateDestinationMetadataByLockingScript(lockingScript: string, metadata: Metadata): Promise<Destination>;
-  NewPaymail(key: string, address: string, publicName?: string, avatar?: string, metadata?: Metadata): Promise<void>;
-  DeletePaymail(address: string): Promise<void>;
   GetTransaction(txID: string): Promise<Transaction>;
   GetTransactions(conditions: Conditions, metadata: Metadata, queryParams: QueryParams): Promise<Transactions>;
   GetTransactionsCount(conditions: Conditions, metadata: Metadata): Promise<number>;

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -148,7 +148,7 @@ class TransportHTTP implements TransportService {
     });
   }
 
-  async AdminDeletePaymail(address: string): Promise<PaymailAddress> {
+  async AdminDeletePaymail(address: string) {
     return await this.doHTTPAdminRequest(`${this.serverUrl}/admin/paymail/delete`, 'DELETE', { address });
   }
 
@@ -560,7 +560,7 @@ class TransportHTTP implements TransportService {
    * @param metadata Metadata The metadata to record on the xPub
    * @returns {XPub}
    */
-  async RegisterXpub(rawXPub: string, metadata: Metadata): Promise<XPub> {
+  async AdminNewXpub(rawXPub: string, metadata: Metadata): Promise<XPub> {
     return await this.doHTTPAdminRequest(`${this.serverUrl}/xpub`, 'POST', {
       key: rawXPub,
       metadata

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -148,7 +148,7 @@ class TransportHTTP implements TransportService {
     });
   }
 
-  async AdminDeletePaymail(address: string) {
+  async AdminDeletePaymail(address: string): Promise<void> {
     return await this.doHTTPAdminRequest(`${this.serverUrl}/admin/paymail/delete`, 'DELETE', { address });
   }
 
@@ -561,7 +561,7 @@ class TransportHTTP implements TransportService {
    * @returns {XPub}
    */
   async AdminNewXpub(rawXPub: string, metadata: Metadata): Promise<XPub> {
-    return await this.doHTTPAdminRequest(`${this.serverUrl}/xpub`, 'POST', {
+    return await this.doHTTPAdminRequest(`${this.serverUrl}/admin/xpub`, 'POST', {
       key: rawXPub,
       metadata
     });


### PR DESCRIPTION
<!--
    Thank you for contributing to our project! Before you submit your Pull Request, please make sure you've completed the items in this checklist.
    Please check the boxes below by putting an x in the [ ] like so: [x]. You can do it right after creating the PR.
-->

# Pull Request Checklist

- [ ] 📖 I created my PR using provided  : [CODE_STANDARDS](https://github.com/BuxOrg/js-buxclient/blob/main/.github/CODE_STANDARDS.md)
- [ ] 📖 I have read the short Code of Conduct: [CODE_OF_CONDUCT](https://github.com/BuxOrg/js-buxclient/blob/main/.github/CODE_OF_CONDUCT.md)
- [ ] 🏠 I tested my changes locally.
- [ ] ✅ I have provided tests for my changes.
- [ ] 📝 I have used conventional commits.
- [ ] 📗 I have updated any related documentation.
- [ ] 💾 PR was issued based on the Github or Jira issue.

# Description

- Adjusted methods to new bux-server router. Moved method which creates pub to Admin section and removed paymail duplicates

<!--
## PR Title as Conventional Commit

Your PR title should also be a [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/). This will assist us in our release process and in assigning semantic version numbers to releases.
-->

<!--
## Related Tickets & Documents

If your changes relate to or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For instance, having the text "closes #1234" would link the current pull request to issue number 1234. And when we merge the pull request, Github will automatically close the issue.

- Related Issue #
- Closes #
-->

<!--
## Feature/Issue Details

Your pull request should be tightly connected to a feature or issue. Ensure that you've covered all necessary pathways and there's a possibility to test code behavior following the issue description or feature specification.
-->
