### PR TITLE
Fix(spv 1222) tslib issue with vanilla js project #2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/spv-wallet-js-client",
-  "version": "1.0.0-beta.26",
+  "version": "1.0.0-beta.27",
   "description": "TypeScript library for connecting to a SPV Wallet server",
   "repository": {
     "type": "git",

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -33,15 +33,20 @@ const config: RollupOptions[] = [
         skip: ['bsv'],
         browser: true,
         preferBuiltins: true,
-        moduleDirectories: ['node_modules'],
       }),
       commonjs(),
       json(),
-      typescript({ tsconfig: "./tsconfig.json", sourceMap: false }),
+      typescript({ 
+        tsconfig: "./tsconfig.json", 
+        sourceMap: false,
+        noEmitHelpers: true,
+        importHelpers: true
+      }),
       nodePolyfills(),
       externals({
         devDeps: true,
         peerDeps: true,
+        exclude: ['tslib']
       }),
     ],
   },
@@ -60,7 +65,12 @@ const config: RollupOptions[] = [
     ],
     external: ['bsv', 'cross-fetch', 'cross-fetch/polyfill'],
     plugins: [
-      typescript({ tsconfig: "./tsconfig.json", sourceMap: false }),
+      typescript({
+        tsconfig: "./tsconfig.json",
+        sourceMap: false,
+        noEmitHelpers: true,
+        importHelpers: true
+      }),
       resolve({
       // @ts-ignore
         skip: ['bsv'],
@@ -68,6 +78,7 @@ const config: RollupOptions[] = [
       externals({
         devDeps: true,
         peerDeps: true,
+        exclude: ['tslib']
       }),
     ],
   },


### PR DESCRIPTION
- chore(rollup): Enable importHelpers and noEmitHelpers for rollup.config file
- chore(rollup): Explicitly exclude 'tslib' from external dependancies

# Pull Request Checklist

- [x] 📖 I created my PR using provided  : [CODE_STANDARDS](https://github.com/bitcoin-sv/spv-wallet-js-client/blob/main/.github/CODE_STANDARDS.md)
- [x] 📖 I have read the short Code of Conduct: [CODE_OF_CONDUCT](https://github.com/bitcoin-sv/spv-wallet-js-client/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] 🏠 I tested my changes locally.
- [ ] ✅ I have provided tests for my changes.
- [x] 📝 I have used conventional commits.
- [ ] 📗 I have updated any related documentation.
- [x] 💾 PR was issued based on the Github or Jira issue.
